### PR TITLE
Add logo and landing-page QR code to receipts

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,6 +305,11 @@
       <div class="modal-content">
         <div class="receipt" id="receipt">
           <div class="receipt-header">
+            <img
+              id="receiptLogo"
+              class="receipt-logo"
+              alt="Salon logo"
+            />
             <h2>Hair Salon</h2>
             <p>123 Beauty Street</p>
             <p>Phone: (555) 123-4567</p>
@@ -327,6 +332,21 @@
           <div class="receipt-footer">
             <p>Thank you for your visit!</p>
             <p>Please come again</p>
+            <div class="receipt-qr hidden" id="receiptQrContainer">
+              <img
+                id="receiptQr"
+                alt="QR code that links to our landing page"
+              />
+              <p class="receipt-qr-caption">Scan to visit our landing page</p>
+              <a
+                id="receiptQrLink"
+                class="receipt-qr-link"
+                href="https://example.com/landing"
+                target="_blank"
+                rel="noopener"
+                >https://example.com/landing</a
+              >
+            </div>
           </div>
         </div>
         <div class="modal-actions">
@@ -353,6 +373,7 @@
       </div>
     </div>
 
+    <script src="./node_modules/qrious/dist/qrious.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "escpos": "^3.0.0-alpha.6"
+        "escpos": "^3.0.0-alpha.6",
+        "qrious": "^4.0.2"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.8.3",
@@ -4844,6 +4845,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/qr-image/-/qr-image-3.2.0.tgz",
       "integrity": "sha512-rXKDS5Sx3YipVsqmlMJsJsk6jXylEpiHRC2+nJy66fxA5ExYyGa4PqwteW69SaVmAb2OQ18HbYriT7cGQMbduw=="
+    },
+    "node_modules/qrious": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/qrious/-/qrious-4.0.2.tgz",
+      "integrity": "sha512-xWPJIrK1zu5Ypn898fBp8RHkT/9ibquV2Kv24S/JY9VYEhMBMKur1gHVsOiNUh7PHP9uCgejjpZUHUIXXKoU/g==",
+      "license": "GPL-3.0"
     },
     "node_modules/qs": {
       "version": "6.5.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "electron": "^37.2.6"
   },
   "dependencies": {
-    "escpos": "^3.0.0-alpha.6"
+    "escpos": "^3.0.0-alpha.6",
+    "qrious": "^4.0.2"
   },
   "config": {
     "forge": {

--- a/script.js
+++ b/script.js
@@ -1,10 +1,30 @@
 // POS System JavaScript
 
+const DEFAULT_LANDING_PAGE_URL = "https://example.com/landing";
+const DEFAULT_LOGO_SVG = `
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80" viewBox="0 0 200 80">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#c77e4d" />
+      <stop offset="100%" stop-color="#8c3f2e" />
+    </linearGradient>
+  </defs>
+  <rect width="200" height="80" rx="16" fill="url(#grad)" />
+  <text x="50%" y="52" text-anchor="middle" font-family="'Segoe UI', sans-serif" font-size="28" fill="#f5f5f5">Salon POS</text>
+</svg>`;
+const DEFAULT_LOGO_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(
+  DEFAULT_LOGO_SVG
+)}`;
+
 class POSSystem {
   constructor() {
     this.orderItems = [];
     this.selectedPaymentMethod = "cash";
     this.taxRate = 0.0825; // 8.25%
+
+    this.landingPageUrl = DEFAULT_LANDING_PAGE_URL;
+    this.logoDataUrl = DEFAULT_LOGO_DATA_URL;
+    this.qrCodeSize = 160;
 
     this.apiBaseUrl = "http://localhost:3000";
     this.appointmentNotificationsPath = "/appointments/notifications";
@@ -22,6 +42,12 @@ class POSSystem {
       typeof globalConfig.appointmentNotificationsPath === "string"
     ) {
       this.appointmentNotificationsPath = globalConfig.appointmentNotificationsPath;
+    }
+    if (globalConfig && typeof globalConfig.landingPageUrl === "string") {
+      this.landingPageUrl = globalConfig.landingPageUrl;
+    }
+    if (globalConfig && typeof globalConfig.logoDataUrl === "string") {
+      this.logoDataUrl = globalConfig.logoDataUrl;
     }
 
     this.notifications = [];
@@ -50,6 +76,8 @@ class POSSystem {
     setInterval(() => this.updateDateTime(), 1000);
 
     this.initializeAppointmentWebSocket();
+
+    this.updateReceiptBranding();
 
     window.addEventListener("beforeunload", () => {
       this.isShuttingDown = true;
@@ -129,6 +157,55 @@ class POSSystem {
         }
       });
     });
+  }
+
+  updateReceiptBranding() {
+    const logoElement = document.getElementById("receiptLogo");
+    if (logoElement) {
+      if (this.logoDataUrl) {
+        logoElement.src = this.logoDataUrl;
+        logoElement.classList.remove("hidden");
+      } else {
+        logoElement.classList.add("hidden");
+      }
+    }
+
+    const qrContainer = document.getElementById("receiptQrContainer");
+    const qrImage = document.getElementById("receiptQr");
+    const qrLink = document.getElementById("receiptQrLink");
+
+    if (!qrContainer || !qrImage || !qrLink) {
+      return;
+    }
+
+    if (!this.landingPageUrl) {
+      qrContainer.classList.add("hidden");
+      return;
+    }
+
+    qrLink.textContent = this.landingPageUrl;
+    qrLink.href = this.landingPageUrl;
+
+    if (window.QRious) {
+      try {
+        const qr = new window.QRious({
+          value: this.landingPageUrl,
+          size: this.qrCodeSize,
+          level: "H",
+        });
+        qrImage.src = qr.toDataURL();
+        qrImage.alt = "QR code linking to landing page";
+        qrImage.classList.remove("hidden");
+      } catch (error) {
+        console.error("Unable to generate QR code:", error);
+        qrImage.classList.add("hidden");
+      }
+      qrContainer.classList.remove("hidden");
+    } else {
+      console.warn("QRious library not available. Displaying landing page URL only.");
+      qrImage.classList.add("hidden");
+      qrContainer.classList.remove("hidden");
+    }
   }
 
   initializeNotificationSystem() {
@@ -1095,10 +1172,14 @@ class POSSystem {
       changeLine.classList.remove("show");
     }
 
+    this.updateReceiptBranding();
+
     document.getElementById("receiptModal").classList.add("show");
   }
 
   async printReceipt() {
+    this.updateReceiptBranding();
+
     // Prepare plain text for ESC/POS printer
     const header = "Hair Salon\n123 Beauty Street\nPhone: (555) 123-4567\n";
     const date = `Date: ${new Date().toLocaleDateString()}\n`;
@@ -1111,10 +1192,18 @@ class POSSystem {
         )
         .join("\n") + "\n";
     const summary = `Subtotal: ${this.getSubtotal().toFixed(2)}\nTax: ${this.getTax().toFixed(2)}\nTotal: ${this.getTotal().toFixed(2)}\nPayment: ${this.selectedPaymentMethod.charAt(0).toUpperCase() + this.selectedPaymentMethod.slice(1)}\n`;
-    const change = document.getElementById("receiptChange")?.textContent || "";
-    const footer =
-      (change ? `Change: ${change}\n` : "") +
-      "\nThank you for your visit!\nPlease come again\n";
+    const change = document
+      .getElementById("receiptChange")
+      ?.textContent.trim();
+    const footerLines = [];
+    if (change) {
+      footerLines.push(`Change: ${change}`);
+    }
+    if (this.landingPageUrl) {
+      footerLines.push(`Scan to visit: ${this.landingPageUrl}`);
+    }
+    footerLines.push("", "Thank you for your visit!", "Please come again", "");
+    const footer = footerLines.join("\n");
 
     // Try to use Electron IPC for Epson printer
     if (window.electronAPI && window.electronAPI.printInvoiceAndOpenDrawer) {
@@ -1148,9 +1237,26 @@ class POSSystem {
             body { font-family: 'Courier New', monospace; margin: 20px; }
             .receipt { max-width: 300px; }
             .receipt-item { display: flex; justify-content: space-between; }
-            .receipt-header { text-align: center; border-bottom: 1px dashed #ccc; padding-bottom: 10px; margin-bottom: 10px; }
+            .receipt-header {
+              text-align: center;
+              border-bottom: 1px dashed #ccc;
+              padding-bottom: 10px;
+              margin-bottom: 10px;
+            }
+            .receipt-logo { display: block; margin: 0 auto 12px; max-width: 140px; }
             .receipt-total { border-top: 1px dashed #ccc; padding-top: 10px; }
             .receipt-footer { text-align: center; font-style: italic; margin-top: 20px; }
+            .receipt-qr { margin-top: 16px; }
+            .receipt-qr img { display: block; margin: 8px auto; width: 140px; height: 140px; }
+            .receipt-qr-caption { font-style: normal; font-size: 0.85rem; color: #333; }
+            .receipt-qr-link {
+              display: block;
+              font-style: normal;
+              font-size: 0.75rem;
+              color: #333;
+              word-break: break-all;
+              text-decoration: none;
+            }
           </style>
         </head>
         <body>

--- a/styles.css
+++ b/styles.css
@@ -600,6 +600,12 @@ body {
   margin-bottom: 1rem;
 }
 
+.receipt-logo {
+  display: block;
+  margin: 0 auto 0.75rem;
+  max-width: 140px;
+}
+
 .receipt-header h2 {
   font-size: 1.2rem;
   margin-bottom: 0.5rem;
@@ -632,6 +638,37 @@ body {
   text-align: center;
   font-style: italic;
   color: #5e3f35;
+}
+
+.receipt-qr {
+  margin-top: 1rem;
+}
+
+.receipt-qr img {
+  display: block;
+  margin: 0.5rem auto;
+  width: 140px;
+  height: 140px;
+}
+
+.receipt-qr-caption {
+  font-style: normal;
+  font-size: 0.85rem;
+  color: #2e2a28;
+}
+
+.receipt-qr-link {
+  display: block;
+  font-style: normal;
+  font-size: 0.75rem;
+  color: #2e2a28;
+  word-break: break-all;
+  text-decoration: none;
+}
+
+.receipt-qr-link:hover,
+.receipt-qr-link:focus {
+  text-decoration: underline;
 }
 
 .change-line {


### PR DESCRIPTION
## Summary
- add the salon logo to printed receipts and style the branding elements
- generate a landing-page QR code for invoices using the QRious library with configurable URLs
- update receipt fallback printing and ESC/POS footer text to mention the landing page link

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6c86c2c9483229105cc467eabe114